### PR TITLE
Use fully qualified container image URL for Podman compatibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   dns-client:
     container_name: dns-client
     hostname: dns-client
-    image: technitium/dns-client:latest
+    image: docker.io/technitium/dns-client:latest
     ports:
       - "8001:8001/tcp" #DNS Client web app
     restart: unless-stopped


### PR DESCRIPTION
Podman does not reliably resolve unqualified image names. This change updates the container image reference to a fully qualified Docker Hub URL to ensure it pulls correctly when using Podman.